### PR TITLE
feat: auto-load LLM config from openclaw.json (Issue #68)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@ API_PORT=18900
 
 # ---------- LLM（实体抽取 / 冥思引擎） ----------
 # 兼容 OpenRouter / Ollama / 任意 OpenAI-compatible 接口
+#
+# 提示：如果你已经配置了 openclaw.json，记忆系统会自动读取其中的 LLM 配置，
+# 无需在此处手动填写。以下变量仅在 openclaw.json 不存在时作为后备。
+#
 OPENAI_API_KEY=sk-your-api-key-here
 OPENAI_BASE_URL=https://openrouter.ai/api/v1
 # Ollama 用户可改为：

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,10 @@ services:
     depends_on:
       neo4j:
         condition: service_healthy
+    # 可选：挂载 openclaw.json 让记忆系统自动读取 LLM 配置（Issue #68）
+    # 取消注释下面两行即可自动继承 OpenClaw 的 LLM 配置
+    # volumes:
+    #   - ${HOME:-~}/.openclaw/openclaw.json:/app/.openclaw/openclaw.json:ro
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:18900/health || exit 1"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,11 @@ services:
         condition: service_healthy
     # 可选：挂载 openclaw.json 让记忆系统自动读取 LLM 配置（Issue #68）
     # 取消注释下面两行即可自动继承 OpenClaw 的 LLM 配置
+    # Linux: /home/user/.openclaw/openclaw.json
+    # macOS: /Users/user/.openclaw/openclaw.json
+    # 也可通过环境变量指定: OPENCLAW_CONFIG_PATH=/path/to/openclaw.json
     # volumes:
-    #   - ${HOME:-~}/.openclaw/openclaw.json:/app/.openclaw/openclaw.json:ro
+    #   - ${HOME}/.openclaw/openclaw.json:/app/.openclaw/openclaw.json:ro
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:18900/health || exit 1"]

--- a/meditation_memory/openclaw_config_loader.py
+++ b/meditation_memory/openclaw_config_loader.py
@@ -27,10 +27,14 @@ def find_openclaw_config() -> Optional[Path]:
         "/app/.openclaw/openclaw.json",
     ]
 
+    seen: set = set()
     for path_str in search_paths:
         if not path_str:
             continue
-        config_path = Path(path_str)
+        config_path = Path(path_str).resolve()
+        if config_path in seen:
+            continue
+        seen.add(config_path)
         if config_path.exists() and config_path.is_file():
             return config_path
 
@@ -87,6 +91,7 @@ def parse_openclaw_config(config: Dict[str, Any]) -> Optional[Dict[str, str]]:
         "base_url": base_url,
         "api_key": api_key,
         "model": model_name,
+        "provider": provider_name,
     }
 
 
@@ -96,7 +101,7 @@ def inject_openclaw_llm_config() -> str:
     仅对未设置的环境变量生效（os.environ.setdefault），
     确保 .env 文件中的显式配置优先级更高。
 
-    返回: "openclaw.json" | ".env" | "defaults"
+    返回: "openclaw.json" | "env" | "defaults"
     """
     config_path = find_openclaw_config()
     if not config_path:
@@ -115,20 +120,32 @@ def inject_openclaw_llm_config() -> str:
         logger.info("Could not extract LLM config from %s", config_path)
         return "defaults"
 
-    # 注入环境变量（仅当未显式设置时）
-    os.environ.setdefault("OPENAI_BASE_URL", llm["base_url"])
-    os.environ.setdefault("OPENAI_API_KEY", llm["api_key"])
-    os.environ.setdefault("LLM_MODEL", llm["model"])
-
-    logger.info(
-        "LLM config loaded from %s: base_url=%s, model=%s",
-        config_path,
-        llm["base_url"],
-        llm["model"],
-    )
-
-    # 判断实际来源
-    if os.environ.get("OPENAI_API_KEY"):
-        return "openclaw.json"
-    else:
+    # 校验 base_url
+    if not llm["base_url"]:
+        logger.warning(
+            "No baseUrl found for provider %s, skipping openclaw.json", llm["provider"]
+        )
         return "defaults"
+
+    # 注入环境变量（仅当未显式设置时），追踪是否真正注入了值
+    injected = False
+    for env_var, value in [
+        ("OPENAI_BASE_URL", llm["base_url"]),
+        ("OPENAI_API_KEY", llm["api_key"]),
+        ("LLM_MODEL", llm["model"]),
+    ]:
+        if env_var not in os.environ:
+            os.environ[env_var] = value
+            injected = True
+
+    if injected:
+        logger.info(
+            "LLM config loaded from %s: base_url=%s, model=%s",
+            config_path,
+            llm["base_url"],
+            llm["model"],
+        )
+        return "openclaw.json"
+
+    logger.info("LLM config already set via .env, skipping openclaw.json")
+    return "env"

--- a/meditation_memory/openclaw_config_loader.py
+++ b/meditation_memory/openclaw_config_loader.py
@@ -1,0 +1,134 @@
+"""
+OpenClaw 配置自动发现模块
+
+从 openclaw.json 自动提取 LLM 配置，消除 .env 冗余。
+优先级：环境变量（.env）> openclaw.json > 默认值
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Optional, Dict, Any
+
+logger = logging.getLogger("openclaw_config_loader")
+
+
+def find_openclaw_config() -> Optional[Path]:
+    """按优先级查找 openclaw.json"""
+    search_paths = [
+        # 1. 显式指定路径（Docker Volume 挂载场景）
+        os.environ.get("OPENCLAW_CONFIG_PATH"),
+        # 2. 用户家目录（OpenClaw 默认位置）
+        os.path.expanduser("~/.openclaw/openclaw.json"),
+        # 3. 工作区根目录（memory_api_server.py 的父目录的父目录）
+        str(Path(__file__).parent.parent / "openclaw.json"),
+        # 4. 容器内挂载路径
+        "/app/.openclaw/openclaw.json",
+    ]
+
+    for path_str in search_paths:
+        if not path_str:
+            continue
+        config_path = Path(path_str)
+        if config_path.exists() and config_path.is_file():
+            return config_path
+
+    return None
+
+
+def parse_openclaw_config(config: Dict[str, Any]) -> Optional[Dict[str, str]]:
+    """从 openclaw.json 提取 LLM 连接信息
+
+    返回 {base_url, api_key, model} 或 None
+    """
+    models = config.get("models", {})
+    providers = models.get("providers", {})
+    defaults = models.get("defaults", {})
+    default_model = defaults.get("model", "")
+
+    if not default_model:
+        logger.debug("No default model found in openclaw.json")
+        return None
+
+    # 解析 provider 名称（如 "qwen/qwen3.6-plus" → "qwen"）
+    if "/" in default_model:
+        provider_name = default_model.split("/")[0]
+        # 处理多层路径如 "openrouter/qwen/qwen-plus" → "openrouter"
+        model_name = "/".join(default_model.split("/")[1:])
+    else:
+        provider_name = default_model
+        model_name = default_model
+
+    if provider_name not in providers:
+        # 尝试第一个可用的 provider
+        if providers:
+            provider_name = list(providers.keys())[0]
+            provider = providers[provider_name]
+            # 尝试推断模型名
+            models_list = provider.get("models", [])
+            if models_list and isinstance(models_list, list) and len(models_list) > 0:
+                first_model = models_list[0]
+                if isinstance(first_model, dict):
+                    model_name = first_model.get("id", first_model.get("name", default_model))
+                else:
+                    model_name = str(first_model)
+            else:
+                model_name = default_model
+        else:
+            logger.debug("No matching provider '%s' in openclaw.json", provider_name)
+            return None
+
+    provider = providers[provider_name]
+    base_url = provider.get("baseUrl", provider.get("base_url", ""))
+    api_key = provider.get("apiKey", provider.get("api_key", ""))
+
+    return {
+        "base_url": base_url,
+        "api_key": api_key,
+        "model": model_name,
+    }
+
+
+def inject_openclaw_llm_config() -> str:
+    """发现 openclaw.json 并注入环境变量
+
+    仅对未设置的环境变量生效（os.environ.setdefault），
+    确保 .env 文件中的显式配置优先级更高。
+
+    返回: "openclaw.json" | ".env" | "defaults"
+    """
+    config_path = find_openclaw_config()
+    if not config_path:
+        logger.info("No openclaw.json found, using .env/defaults for LLM config")
+        return "defaults"
+
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        logger.warning("Failed to parse %s: %s", config_path, e)
+        return "defaults"
+
+    llm = parse_openclaw_config(config)
+    if not llm:
+        logger.info("Could not extract LLM config from %s", config_path)
+        return "defaults"
+
+    # 注入环境变量（仅当未显式设置时）
+    os.environ.setdefault("OPENAI_BASE_URL", llm["base_url"])
+    os.environ.setdefault("OPENAI_API_KEY", llm["api_key"])
+    os.environ.setdefault("LLM_MODEL", llm["model"])
+
+    logger.info(
+        "LLM config loaded from %s: base_url=%s, model=%s",
+        config_path,
+        llm["base_url"],
+        llm["model"],
+    )
+
+    # 判断实际来源
+    if os.environ.get("OPENAI_API_KEY"):
+        return "openclaw.json"
+    else:
+        return "defaults"

--- a/memory_api_server.py
+++ b/memory_api_server.py
@@ -30,6 +30,11 @@ from pydantic import BaseModel
 # 添加项目根目录到路径，以便导入 meditation_memory
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+# ========== Issue #68: 自动从 openclaw.json 加载 LLM 配置 ==========
+from meditation_memory.openclaw_config_loader import inject_openclaw_llm_config
+
+_llm_config_source = inject_openclaw_llm_config()
+
 from meditation_memory.graph_store import GraphStore
 from meditation_memory.entity_extractor import Entity, Relation
 from meditation_memory.memory_system import MemorySystem
@@ -169,6 +174,12 @@ class FeedbackResponse(BaseModel):
 @app.on_event("startup")
 async def startup_event():
     """启动时初始化数据库并开启调度器"""
+    # Log LLM config source (Issue #68)
+    if _llm_config_source == "openclaw.json":
+        logger.info("LLM configuration loaded from openclaw.json")
+    elif _llm_config_source == "defaults":
+        logger.info("Using default LLM configuration (.env or built-in defaults)")
+
     if not store.verify_connectivity():
         logger.error("Failed to connect to Neo4j. API server may not work correctly.")
     else:

--- a/memory_api_server.py
+++ b/memory_api_server.py
@@ -177,7 +177,9 @@ async def startup_event():
     # Log LLM config source (Issue #68)
     if _llm_config_source == "openclaw.json":
         logger.info("LLM configuration loaded from openclaw.json")
-    elif _llm_config_source == "defaults":
+    elif _llm_config_source == "env":
+        logger.info("LLM configuration sourced from .env (openclaw.json detected but not overriding)")
+    else:
         logger.info("Using default LLM configuration (.env or built-in defaults)")
 
     if not store.verify_connectivity():


### PR DESCRIPTION
## Summary

实现 Issue #68：记忆系统自动读取 OpenClaw 的 LLM 配置，消除 .env 冗余。

## 变更

### 新增文件
- **`meditation_memory/openclaw_config_loader.py`** — 配置自动发现模块
  - `find_openclaw_config()`：按优先级搜索 openclaw.json（`~/.openclaw/` → 工作区 → 容器路径）
  - `parse_openclaw_config()`：解析 `models.providers.*` 和 `defaults.model`
  - `inject_openclaw_llm_config()`：通过 `setdefault` 注入环境变量

### 修改文件
- **`memory_api_server.py`** — 启动时调用配置加载器，日志输出配置来源
- **`.env.example`** — 添加自动发现机制说明
- **`docker-compose.yml`** — 添加可选的 openclaw.json volume 挂载

## 配置优先级

```
.env 环境变量 > openclaw.json > 内置默认值
```

## 支持的提供商格式

| 提供商 | 模型名格式 | 自动解析结果 |
|--------|-----------|-------------|
| 阿里云 Dashscope | `qwen/qwen3.6-plus` | baseUrl + apiKey + qwen3.6-plus |
| OpenRouter | `openrouter/qwen/qwen-plus` | baseUrl + apiKey + qwen/qwen-plus |
| Ollama | `ollama/qwen2.5-coder:7b` | baseUrl + 空 key + qwen2.5-coder:7b |

## 测试

- ✅ Dashscope 配置解析测试通过
- ✅ 优先级测试通过（.env 不被覆盖）
- ✅ OpenRouter 嵌套模型名解析测试通过

## Docker 部署

用户只需取消注释 `docker-compose.yml` 中的 volume 挂载行即可自动继承 LLM 配置：

```yaml
# volumes:
#   - \${HOME:-~}/.openclaw/openclaw.json:/app/.openclaw/openclaw.json:ro
```

Closes #68