### PR TITLE
fix: 修复冥思步骤 3/4/5 的 LLM 返回类型错误 (Issue #67)

### DIFF
--- a/meditation_memory/graph_store.py
+++ b/meditation_memory/graph_store.py
@@ -1758,6 +1758,48 @@ class GraphStore:
             result = session.run(query, names=all_names)
             return [dict(record) for record in result]
 
+    def _text_jaccard(self, a: str, b: str) -> float:
+        """计算两段文本的 Jaccard 相似度（基于字符 bigram）。"""
+        if not a or not b:
+            return 0.0
+        def ngrams(s, n=2):
+            return set(s[i:i+n] for i in range(len(s) - n + 1))
+        sa, sb = ngrams(a), ngrams(b)
+        if not sa or not sb:
+            return 0.0
+        return len(sa & sb) / len(sa | sb)
+
+    def _find_similar_meta_knowledge(
+        self,
+        summary: str,
+        similarity_threshold: float = 0.85,
+    ) -> Optional[str]:
+        """
+        查找与给定摘要语义相似的已有元知识节点。
+
+        使用 Jaccard bigram 相似度，超过阈值则认为重复。
+
+        Returns:
+            相似节点的名称，或 None
+        """
+        query = """
+        MATCH (m:Entity {entity_type: "meta_knowledge"})
+        WHERE m.description IS NOT NULL
+        RETURN m.name AS name, m.description AS description
+        LIMIT 200
+        """
+        try:
+            with self.driver.session(database=self._config.database) as session:
+                result = session.run(query)
+                for record in result:
+                    desc = record["description"]
+                    sim = self._text_jaccard(summary, desc)
+                    if sim >= similarity_threshold:
+                        return record["name"]
+        except Exception as e:
+            logger.warning("Failed to find similar meta knowledge: %s", e)
+        return None
+
     def create_meta_knowledge_node(
         self,
         summary: str,
@@ -1768,6 +1810,9 @@ class GraphStore:
         """
         创建元知识节点并建立到底层事实节点的 SUMMARIZES 关系。
 
+        创建前会检查是否存在语义相似的已有元知识节点（Jaccard 相似度 > 0.85），
+        若存在则复用该节点并更新描述和关系，避免产生大量重复的 META 节点。
+
         Args:
             summary: 元知识摘要文本
             related_entity_names: 相关底层实体名称列表
@@ -1777,7 +1822,52 @@ class GraphStore:
         Returns:
             是否成功
         """
-        # 使用摘要的前 50 字符作为名称
+        # 去重：查找语义相似的已有元知识节点
+        existing_name = self._find_similar_meta_knowledge(summary, similarity_threshold=0.85)
+        if existing_name:
+            # 复用已有节点：更新描述并建立新关系
+            reuse_query = """
+            MATCH (m:Entity {name: $name, entity_type: $entity_type})
+            SET m.description = $summary,
+                m.updated_at = timestamp(),
+                m.mention_count = coalesce(m.mention_count, 0) + 1
+            RETURN elementId(m) AS eid
+            """
+            link_query = """
+            MATCH (m:Entity {name: $meta_name, entity_type: $entity_type})
+            MATCH (e:Entity {name: $entity_name})
+            WHERE NOT e:Archived
+            MERGE (m)-[r:RELATES_TO {relation_type: $rel_type}]->(e)
+            ON CREATE SET
+                r.created_at = timestamp(),
+                r.updated_at = timestamp(),
+                r.mention_count = 1,
+                r.properties = "{}"
+            RETURN type(r) AS rel_type
+            """
+            try:
+                with self.driver.session(database=self._config.database) as session:
+                    session.run(
+                        reuse_query,
+                        name=existing_name,
+                        entity_type=meta_entity_type,
+                        summary=summary,
+                    )
+                    for entity_name in related_entity_names:
+                        session.run(
+                            link_query,
+                            meta_name=existing_name,
+                            entity_type=meta_entity_type,
+                            entity_name=entity_name,
+                            rel_type=summarizes_rel_type,
+                        )
+                logger.info("Reused similar meta knowledge node: %s", existing_name)
+                return True
+            except Exception as e:
+                logger.error("Failed to reuse meta knowledge node: %s", e)
+                return False
+
+        # 无相似节点，创建新节点
         meta_name = f"[META] {summary[:50]}..." if len(summary) > 50 else f"[META] {summary}"
 
         create_query = """

--- a/meditation_memory/meditation_worker.py
+++ b/meditation_memory/meditation_worker.py
@@ -796,6 +796,9 @@ class MeditationEngine:
         if pairs:
             judgments = self.llm.judge_synonym_entities(pairs)
             for j in judgments:
+                if not isinstance(j, dict):
+                    logger.warning("Step 3.1: Skipping non-dict judgment item: %s", j)
+                    continue
                 idx = j.get("pair_index")
                 if idx is not None and idx < len(pairs) and j.get("is_same"):
                     pair = pairs[idx]
@@ -854,6 +857,9 @@ class MeditationEngine:
         if missing_meta:
             enriched = self.llm.infer_entity_metadata(missing_meta)
             for item in enriched:
+                if not isinstance(item, dict):
+                    logger.warning("Step 3.3: Skipping non-dict metadata item: %s", item)
+                    continue
                 name = item.get("name")
                 if not name: continue
                 if result.dry_run:
@@ -885,6 +891,9 @@ class MeditationEngine:
         if generic_rels:
             relabels = self.llm.relabel_relations(generic_rels, self.config.restructuring.relation_ontology)
             for r in relabels:
+                if not isinstance(r, dict):
+                    logger.warning("Step 4.1: Skipping non-dict relabel item: %s", r)
+                    continue
                 idx = r.get("index")
                 new_type = r.get("new_relation_type")
                 if idx is not None and idx < len(generic_rels) and new_type and new_type != "related_to":
@@ -915,6 +924,9 @@ class MeditationEngine:
 
         inferred = self.llm.infer_implicit_relations(edges, node_names)
         for inf in inferred:
+            if not isinstance(inf, dict):
+                logger.warning("Step 4.2: Skipping non-dict inferred relation: %s", inf)
+                continue
             if result.dry_run:
                 result.suggestions.append({
                     "step": "restructuring",
@@ -947,6 +959,9 @@ class MeditationEngine:
         if needs_eval:
             evals = self.llm.evaluate_semantic_importance(needs_eval)
             for ev in evals:
+                if not isinstance(ev, dict):
+                    logger.warning("Step 5: Skipping non-dict eval item: %s", ev)
+                    continue
                 semantic_scores[ev["name"]] = ev.get("semantic_score", 0.5)
 
         updates = []


### PR DESCRIPTION
## 修复内容

### 1. LLM 返回类型保护（冥思步骤 3/4/5 崩溃修复）

为所有遍历 LLM 返回结果的循环添加 `isinstance(item, dict)` 类型保护，防止 LLM 返回畸形 JSON（列表中包含非 dict 元素）导致崩溃。

| 步骤 | 问题 | 修复 |
|------|------|------|
| Step 3.1 同义词合并 | LLM 返回 int 而非 dict → `'int' object has no attribute 'get'` | 添加类型检查，跳过非 dict 项 |
| Step 3.3 元数据补充 | 同上 | 同上 |
| Step 4.1 关系重标注 | 同上 | 同上 |
| Step 4.2 隐含关系推断 | 同上 | 同上 |
| Step 5 权重强化 | 同上 → `must be real number, not NoneType` | 同上 |

### 2. 元知识节点去重机制

新增创建 META 节点前的语义去重：
- `_text_jaccard`: 基于字符 bigram 的 Jaccard 相似度计算
- `_find_similar_meta_knowledge`: 查找相似度 > 0.85 的已有节点
- 修改 `create_meta_knowledge_node`: 若存在相似节点则复用（更新描述+关系）而非创建新节点

解决 20+ 个关于相同主题的重复 META 节点问题。

### 根因

`_parse_json_response()` 虽然尝试解析 JSON，但 LLM 偶尔会返回格式不规范的响应（如 `[1, 2, 3]` 而非 `[{"pair_index": 0, ...}]`），导致下游代码对非 dict 对象调用 `.get()` 时崩溃。

### 修复策略

- 所有 `for item in llm_results` 循环开头添加 `if not isinstance(item, dict): logger.warning(...); continue`
- 不改变正常流程，仅增加防御性检查
- 记录警告日志便于排查 LLM 返回异常
- META 节点复用而非创建重复项