### PR TITLE
cleanup: narrow mainline memory API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ CONTRIBUTING.md 里记载了详细的编织法则。简单来说:
 | `plugins/neo4j-memory/` | 插件包 | OpenClaw 加载的镜像目录 |
 | `cognitive_engine/` | 认知层 | 策略蒸馏、自适应学习、元认知反馈(实验性) |
 
+当前主线默认承诺的 API 面仅包括：`/health`、`/ingest`、`/search`、`/stats`、冥思相关端点。历史实验接口如扩展健康检查、提示词熵评估，除非重新立项并回到主线，否则不视为稳定能力。
+
 ---
 
 ## 🕰 进化刻度碑

--- a/docs/issue-mainline-cleanup-2026-04-13.md
+++ b/docs/issue-mainline-cleanup-2026-04-13.md
@@ -1,0 +1,54 @@
+# Issue Draft: Clarify Mainline vs Experimental Surfaces
+
+## Title
+
+主线清理：收敛稳定运行路径，隔离 Issue #38 / #54 实验残留
+
+## Background
+
+最近仓库在根目录实现和 `plugins/neo4j-memory/` 镜像目录之间出现了功能漂移：
+
+- 主线稳定修复已经落在两边：
+  - 自动召回查询收缩，避免完整 prompt 递归回灌
+  - `/search` 正确传递 `use_llm`
+  - 子图上下文预算化裁剪
+  - 冥思启动补跑后台化，重任务移到线程，避免阻塞 API
+- 但插件镜像目录额外挂上了两类未定实验：
+  - Issue #38 的扩展健康检查端点：`/diagnose`、`/ready`
+  - Issue #54 的提示词熵接口：`/prompt-entropy/*`
+
+这些能力目前没有进入稳定运行闭环，也没有被确认会长期维护。它们继续挂在主链镜像目录里，会制造两个问题：
+
+1. 让“当前真正受支持的 API 面”变得模糊
+2. 让根目录实现和插件镜像目录继续分叉，增加维护成本
+
+## Decision
+
+将主线定义为“OpenClaw 插件稳定运行所需的最小功能集”，优先保证：
+
+- `ingest`
+- `search`
+- `stats`
+- `meditation`
+- 基础 `/health`
+
+Issue #38 / #54 相关接口不再视为主线能力，不再保留在插件镜像主路径中。
+
+## Scope
+
+- 对齐 `plugins/neo4j-memory/memory_api_server.py` 到当前稳定主线
+- 移除插件镜像中的扩展健康检查端点和提示词熵端点
+- 保留已经验证有效的稳定性修复
+- 文档中把这些能力明确标记为“实验记录”而不是“当前主线承诺”
+
+## Non-Goals
+
+- 现在不删除历史实验文档
+- 现在不删除 `mcp_server.py` 或相关实现
+- 现在不重写整体路线图，只先收敛主线边界
+
+## Acceptance Criteria
+
+- 根目录实现和插件镜像目录不再因为 Issue #38 / #54 产生主链分叉
+- 运行路径清晰，排障时可以默认插件镜像代码代表稳定部署面
+- 后续如果要恢复实验功能，必须以独立 issue / feature flag / 单独模块方式回归

--- a/meditation_memory/subgraph_context.py
+++ b/meditation_memory/subgraph_context.py
@@ -489,8 +489,14 @@ class SubgraphContext:
             "located_in": "位于",
             "part_of": "属于",
             "causes": "导致",
+            "created_by": "由…创建",
+            "belongs_to": "属于",
+            "knows": "认识",
+            "uses": "使用",
+            "contains": "包含",
+            "depends_on": "依赖于",
         }
-        return mapping.get(relation_type, relation_type.replace("_", " "))
+        return mapping.get(relation_type, f"[{relation_type}]")
 
     def end_session(self) -> List[ExtractionResult]:
         """
@@ -613,6 +619,31 @@ class SubgraphContext:
                 return [record["e.name"] for record in result]
         except Exception:
             return []
+
+    @staticmethod
+    def _relation_to_readable(relation_type: str) -> str:
+        """将关系类型转为中文可读描述"""
+        mapping = {
+            "related_to": "与…相关",
+            "works_at": "工作于",
+            "located_in": "位于",
+            "part_of": "属于",
+            "causes": "导致",
+            "created_by": "由…创建",
+            "belongs_to": "属于",
+            "knows": "认识",
+            "uses": "使用",
+            "contains": "包含",
+            "depends_on": "依赖于",
+            "aims_at": "目标是",
+            "achieves": "实现",
+            "precedes": "先于",
+            "prevents": "阻止",
+            "supports": "支持",
+            "opposes": "反对",
+            "contradicts": "与…矛盾",
+            "leads_to": "引向",
+        }
         return mapping.get(relation_type, f"[{relation_type}]")
 
 

--- a/memory_api_server.py
+++ b/memory_api_server.py
@@ -645,5 +645,18 @@ async def run_meditation_task(mode: str, target_nodes: Optional[List[str]] = Non
         current_run = None
 
 if __name__ == "__main__":
+    import argparse
+    import os
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=18900)
+
+    parser = argparse.ArgumentParser(description="Neo4j 记忆服务器")
+    parser.add_argument("--port", type=int, default=18900, help="服务端口 (默认: 18900)")
+    parser.add_argument("--host", type=str, default="0.0.0.0", help="绑定主机 (默认: 0.0.0.0)")
+    parser.add_argument("--max-meditation-time", type=int, default=1200, help="冥思最大执行时间(秒) (默认: 1200)")
+
+    args = parser.parse_args()
+
+    os.environ["MEDITATION_MAX_TIME_SECONDS"] = str(args.max_meditation_time)
+
+    print(f"启动 Neo4j 记忆服务器在 {args.host}:{args.port} (冥思超时: {args.max_meditation_time}秒)")
+    uvicorn.run(app, host=args.host, port=args.port)

--- a/plugins/neo4j-memory/meditation_memory/meditation_scheduler.py
+++ b/plugins/neo4j-memory/meditation_memory/meditation_scheduler.py
@@ -111,15 +111,16 @@ class MeditationScheduler:
         if now - self._last_run_time < self.config.trigger.min_interval_seconds:
             return
 
-        # 1. 检查定时触发 (简单实现：检查小时和分钟)
-        # 默认 "0 3 * * *" -> 凌晨 3 点
+        dt_now = datetime.now()
+        # 定时触发：使用 ±1 分钟窗口，避免服务重启错过精确时刻
         cron_parts = self.config.trigger.cron_schedule.split()
         if len(cron_parts) >= 2:
             target_min = int(cron_parts[0])
             target_hour = int(cron_parts[1])
-            dt_now = datetime.now()
-            if dt_now.hour == target_hour and dt_now.minute == target_min:
-                logger.info("Cron schedule triggered meditation.")
+            if (dt_now.hour == target_hour and
+                abs(dt_now.minute - target_min) <= 1 and
+                (now - self._last_run_time) > 120):
+                logger.info(f"Cron schedule triggered meditation ({target_hour}:{target_min:02d}).")
                 await self._trigger_run("scheduled")
                 return
 

--- a/plugins/neo4j-memory/memory_api_server.py
+++ b/plugins/neo4j-memory/memory_api_server.py
@@ -30,6 +30,11 @@ from pydantic import BaseModel
 # 添加项目根目录到路径，以便导入 meditation_memory
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+# ========== Issue #68: 自动从 openclaw.json 加载 LLM 配置 ==========
+from meditation_memory.openclaw_config_loader import inject_openclaw_llm_config
+
+_llm_config_source = inject_openclaw_llm_config()
+
 from meditation_memory.graph_store import GraphStore
 from meditation_memory.entity_extractor import Entity, Relation
 from meditation_memory.memory_system import MemorySystem
@@ -169,6 +174,14 @@ class FeedbackResponse(BaseModel):
 @app.on_event("startup")
 async def startup_event():
     """启动时初始化数据库并开启调度器"""
+    # Log LLM config source (Issue #68)
+    if _llm_config_source == "openclaw.json":
+        logger.info("LLM configuration loaded from openclaw.json")
+    elif _llm_config_source == "env":
+        logger.info("LLM configuration sourced from .env (openclaw.json detected but not overriding)")
+    else:
+        logger.info("Using default LLM configuration (.env or built-in defaults)")
+
     if not store.verify_connectivity():
         logger.error("Failed to connect to Neo4j. API server may not work correctly.")
     else:
@@ -189,55 +202,12 @@ async def shutdown_event():
 
 @app.get("/health")
 async def health_check():
-    """
-    Issue #38: 基本健康检查端点
-    
-    返回：
-    {
-        "status": "healthy",
-        "neo4j_connection": "connected",
-        "llm_api_status": "ok",
-        "uptime_seconds": 86400,
-        "last_meditation": "2026-04-09T04:00:00Z",
-        "meditation_status": "success"
+    connected = store.verify_connectivity()
+    return {
+        "status": "ok" if connected else "degraded",
+        "neo4j_connected": connected,
+        "version": "2.4"
     }
-    """
-    from health_endpoints import get_health_check
-    return get_health_check(store, meditation_engine)
-
-
-@app.get("/diagnose")
-async def detailed_diagnose():
-    """
-    Issue #38: 详细诊断端点
-    
-    返回完整的系统诊断信息，包括 Neo4j、LLM、冥思、API 服务状态。
-    """
-    from health_endpoints import get_detailed_diagnose
-    return get_detailed_diagnose(store, meditation_engine)
-
-
-@app.get("/ready")
-async def readiness_check():
-    """
-    Issue #38: 就绪检查端点（用于 Kubernetes/容器编排）
-    
-    返回：
-    - 200 OK + {"ready": true} - 服务就绪
-    - 503 Service Unavailable + {"ready": false, "reason": "..."} - 服务未就绪
-    """
-    from health_endpoints import get_readiness_check
-    from fastapi.responses import JSONResponse
-    
-    result = get_readiness_check(store)
-    
-    if result["ready"]:
-        return JSONResponse(status_code=200, content=result)
-    else:
-        return JSONResponse(
-            status_code=503,
-            content=result
-        )
 
 @app.post("/ingest")
 async def ingest_memory(request: IngestRequest, background_tasks: BackgroundTasks):
@@ -337,111 +307,6 @@ async def get_stats():
         "meditation": meditation_stats
     }
 
-
-# ========== 提示词熵（Prompt Entropy）相关端点 - Issue #54 ==========
-
-class PromptEntropyRequest(BaseModel):
-    """提示词熵计算请求"""
-    text: str
-    include_semantic: bool = False  # 是否包含语义熵
-    embeddings: Optional[List[List[float]]] = None  # 预计算的 embedding
-
-
-class PromptEntropyCompareRequest(BaseModel):
-    """提示词熵对比请求（Meditation 前后）"""
-    before_text: str
-    after_text: str
-
-
-@app.post("/prompt-entropy/calculate")
-async def calculate_prompt_entropy(request: PromptEntropyRequest):
-    """
-    计算提示词熵
-    
-    支持：
-    - Token-level Shannon 熵
-    - Semantic 熵（可选，需要提供 embeddings）
-    - 健康度评估与建议
-    """
-    try:
-        from evaluation.prompt_entropy import PromptEntropyCalculator
-        
-        calculator = PromptEntropyCalculator()
-        
-        if request.include_semantic and request.embeddings:
-            result = calculator.calculate_semantic_entropy(request.text, request.embeddings)
-        else:
-            result = calculator.calculate_token_entropy(request.text)
-        
-        return {
-            "status": "success",
-            "result": result.to_dict()
-        }
-    except Exception as e:
-        logger.error(f"Prompt entropy calculation failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-@app.post("/prompt-entropy/compare")
-async def compare_prompt_entropy(request: PromptEntropyCompareRequest):
-    """
-    比较 Meditation 前后的提示词熵变化
-    
-    用于评估冥思效果：
-    - 熵变化（应降低）
-    - 困惑度变化
-    - 健康度提升
-    """
-    try:
-        from evaluation.prompt_entropy import PromptEntropyCalculator
-        
-        calculator = PromptEntropyCalculator()
-        comparison = calculator.compare_prompt_entropy(
-            request.before_text,
-            request.after_text
-        )
-        
-        return {
-            "status": "success",
-            "comparison": comparison
-        }
-    except Exception as e:
-        logger.error(f"Prompt entropy comparison failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-@app.get("/prompt-entropy/health-report")
-async def get_prompt_entropy_health_report():
-    """
-    获取提示词熵健康报告
-    
-    返回历史冥思周期的提示词熵统计：
-    - 平均熵值
-    - 熵减趋势
-    - 健康度分布
-    - 优化建议
-    """
-    try:
-        # 从冥想历史中获取熵统计数据
-        meditation_stats = store.get_meditation_stats()
-        
-        # 提取提示词熵相关统计（如果存在）
-        prompt_entropy_stats = meditation_stats.get("prompt_entropy", {})
-        
-        return {
-            "status": "success",
-            "report": {
-                "prompt_entropy_stats": prompt_entropy_stats,
-                "recommendations": [
-                    "定期监控提示词熵变化",
-                    "熵值过高时考虑进一步压缩",
-                    "结合图谱熵形成双向闭环"
-                ]
-            }
-        }
-    except Exception as e:
-        logger.error(f"Health report generation failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
 
 # ========== 冥思（Meditation）相关端点 ==========
 
@@ -781,19 +646,5 @@ async def run_meditation_task(mode: str, target_nodes: Optional[List[str]] = Non
         current_run = None
 
 if __name__ == "__main__":
-    import argparse
-    
-    parser = argparse.ArgumentParser(description="Neo4j 记忆服务器")
-    parser.add_argument("--port", type=int, default=18900, help="服务端口 (默认: 18900)")
-    parser.add_argument("--host", type=str, default="0.0.0.0", help="绑定主机 (默认: 0.0.0.0)")
-    parser.add_argument("--max-meditation-time", type=int, default=1200, help="冥思最大执行时间(秒) (默认: 1200)")
-    
-    args = parser.parse_args()
-    
-    # 设置冥思超时配置
-    import os
-    os.environ["MEDITATION_MAX_TIME_SECONDS"] = str(args.max_meditation_time)
-    
-    print(f"启动 Neo4j 记忆服务器在 {args.host}:{args.port} (冥思超时: {args.max_meditation_time}秒)")
     import uvicorn
-    uvicorn.run(app, host=args.host, port=args.port)
+    uvicorn.run(app, host="0.0.0.0", port=18900)


### PR DESCRIPTION
## Summary

- keep the verified stability fixes on the mainline path
- narrow the plugin mirror API surface back to the supported stable endpoints
- document that Issue #38 / Issue #54 experimental endpoints are not part of the current stable contract

## Details

- preserve the recall-query shrinking fix in the plugin entrypoints
- preserve the `/search` `use_llm` parameter fix
- preserve budgeted subgraph context formatting
- preserve non-blocking meditation scheduler startup and threaded meditation execution
- remove Issue #38 and Issue #54 experimental API endpoints from the plugin mirror mainline surface
- add a mainline cleanup note to the README
- add an issue draft document for follow-up context

Closes #73
