### PR TITLE
docs: add LangGraph/OpenClaw compatibility workflow

### DIFF
--- a/docs/langgraph-openclaw-compatibility-matrix.md
+++ b/docs/langgraph-openclaw-compatibility-matrix.md
@@ -1,0 +1,67 @@
+# LangGraph × OpenClaw Compatibility Matrix
+
+This file records tested version pairs for the LangGraph ↔ OpenClaw integration layer.
+
+## Status legend
+
+- `stable` — validated and suitable for `main`
+- `testing` — under active sync validation
+- `blocked` — known incompatibility exists
+- `retired` — previously supported but no longer maintained
+
+## Version pairs
+
+| Integration line | OpenClaw | LangGraph | Plugin contract | Runtime contract | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| v0.1.x | TBD | TBD | v1 | v1 | testing | Fill after first explicit validation pass |
+
+## Validation checklist per row
+
+For a row to be marked `stable`, verify all of the following:
+
+- plugin loads successfully
+- `/health` succeeds against the runtime
+- `before_agent_start` contract passes
+- `agent_end` contract passes
+- `before_compaction` contract passes
+- graceful degradation behavior is confirmed
+- docs match actual config and endpoint shape
+
+## Current contract versions
+
+### Plugin-side lifecycle contract
+
+- `before_agent_start`
+- `agent_end`
+- `before_compaction`
+
+### Runtime endpoints
+
+- `GET /health`
+- `POST /runtime/before-agent-start`
+- `POST /runtime/agent-end`
+- `POST /runtime/before-compaction`
+
+## Upgrade notes template
+
+When adding a new tested row, include notes like:
+
+- what changed upstream
+- whether any payload shape changed
+- whether any config compatibility shim was added
+- whether any tests were added or updated
+- whether rollout should stay staged
+
+## Example entry format
+
+```markdown
+### v0.1.x validation notes
+
+- OpenClaw: <version>
+- LangGraph: <version>
+- Result: testing / stable / blocked
+- Notes:
+  - <note 1>
+  - <note 2>
+```
+

--- a/docs/langgraph-openclaw-compatibility-policy.md
+++ b/docs/langgraph-openclaw-compatibility-policy.md
@@ -1,0 +1,246 @@
+# LangGraph × OpenClaw Compatibility Policy
+
+## Purpose
+
+This document defines how to evolve a LangGraph ↔ OpenClaw integration layer while both upstream projects continue to change.
+
+The goal is to keep the integration stable without forcing the project to chase every upstream release immediately.
+
+## Core strategy
+
+Treat this project as an **integration layer**, not as a mirror of either upstream.
+
+- **OpenClaw** remains the host runtime and execution boundary.
+- **LangGraph** remains the orchestration runtime.
+- **This repo** owns the compatibility contract between them.
+
+That means the primary artifact of this project is:
+
+- plugin/runtime lifecycle contracts
+- adapter boundaries
+- compatibility-tested version combinations
+- smoke tests and degradation behavior
+
+## Compatibility model
+
+The `main` branch must track a **known-good version pair**, not `latest` from both sides.
+
+Example:
+
+| Integration layer | OpenClaw | LangGraph | Status |
+| --- | --- | --- | --- |
+| v0.1.x | pinned tested version | pinned tested version | stable |
+| v0.2.x | next candidate | next candidate | testing |
+
+### Rules
+
+1. `main` only carries combinations that were explicitly tested.
+2. Upstream updates land in dedicated sync branches first.
+3. A new upstream version is not adopted until contract tests pass.
+4. Experimental support may live in `next`, but should not redefine the stable matrix until validated.
+
+## Branch policy
+
+### Stable branches
+
+- `main` — latest validated integration line
+- `next` — upcoming integration line / staging branch
+
+### Upstream sync branches
+
+- `sync/openclaw-<version>`
+- `sync/langgraph-<version>`
+- `sync/openclaw-<version>-langgraph-<version>` when both need coordinated validation
+
+### Feature / fix branches
+
+- `feat/plugin-hook-<topic>`
+- `feat/runtime-contract-<topic>`
+- `fix/openclaw-compat-<topic>`
+- `fix/langgraph-compat-<topic>`
+- `docs/<topic>`
+- `test/<topic>`
+
+## Adapter boundaries
+
+Do not scatter upstream-specific calls across the codebase.
+
+### OpenClaw-facing boundary
+
+Keep OpenClaw-specific logic concentrated in a thin adapter layer, for example:
+
+- plugin entry
+- lifecycle hook wiring
+- config reading
+- context injection adaptation
+- graceful degradation handling
+
+### LangGraph-facing boundary
+
+Keep LangGraph-specific logic concentrated in a runtime adapter layer, for example:
+
+- runtime client
+- request/response translation
+- state checkpoint payload conversion
+- reflection scheduling requests
+
+### Why this matters
+
+When OpenClaw or LangGraph changes upstream, most compatibility work should stay inside one boundary layer instead of leaking across the entire project.
+
+## Release policy
+
+### Stable releases
+
+A stable release should document:
+
+- supported OpenClaw version
+- supported LangGraph version
+- supported runtime endpoints
+- known limitations
+- required smoke tests
+
+### Candidate releases
+
+If upstream drift is being evaluated, publish it as a candidate line first:
+
+- tag or branch it as testing
+- do not silently replace the stable matrix
+- record incompatible behavior before promotion
+
+## Upstream sync policy
+
+Do not continuously chase head on both upstreams.
+
+Instead, use a **sync window**.
+
+Recommended cadence:
+
+- evaluate upstream changes weekly or biweekly
+- open a dedicated sync branch
+- run contract tests
+- merge only if the validated pair remains healthy
+
+### OpenClaw changes likely to matter
+
+- plugin API shape
+- lifecycle hook names or payloads
+- config shape
+- session payload shape
+- compaction timing / semantics
+
+### LangGraph changes likely to matter
+
+- runtime server pattern
+- graph/state interfaces
+- checkpoint APIs
+- async orchestration behavior
+- dependency / packaging changes
+
+## Required validation gates
+
+Every upstream sync branch should run the smallest meaningful compatibility suite.
+
+Minimum gates:
+
+1. plugin load / registration smoke test
+2. runtime health check
+3. `before_agent_start` contract test
+4. `agent_end` contract test
+5. `before_compaction` contract test
+6. graceful degradation test when runtime is unavailable
+
+If one of these fails, the branch is not ready for promotion to `main`.
+
+## Change classification
+
+### Safe to merge independently
+
+- docs only
+- additional tests
+- logging improvements
+- non-breaking internal refactors
+
+### Requires compatibility verification
+
+- plugin lifecycle hook changes
+- config parsing changes
+- request/response schema changes
+- LangGraph runtime endpoint changes
+- timeout / degradation behavior changes
+
+### Requires a sync branch
+
+- OpenClaw upstream upgrade
+- LangGraph upstream upgrade
+- simultaneous upgrade on both sides
+
+## Commit and PR guidance
+
+### Commit style
+
+Prefer narrow commits:
+
+- `feat: add before-agent-start contract adapter`
+- `fix: support openclaw pluginConfig in adapter`
+- `test: add compaction compatibility smoke test`
+- `docs: define langgraph-openclaw compatibility policy`
+
+### PR style
+
+A PR should answer one main question:
+
+- Does it change the OpenClaw boundary?
+- Does it change the LangGraph boundary?
+- Does it change the compatibility matrix?
+- Does it only improve docs/tests?
+
+Avoid mixing all four in one PR.
+
+## Roadmap sequencing
+
+Recommended order:
+
+### Phase 1 — integration scaffold
+
+- plugin hook wiring
+- runtime client
+- health check
+- graceful degradation
+
+### Phase 2 — contract stabilization
+
+- fixed runtime endpoints
+- typed payloads
+- smoke tests for each lifecycle hook
+
+### Phase 3 — upstream drift management
+
+- compatibility matrix
+- sync branches
+- repeatable contract verification
+
+### Phase 4 — advanced orchestration
+
+- richer planning hints
+- checkpoint restore
+- reflection governance
+- optional memory backends
+
+## Non-goals for now
+
+This policy intentionally does **not** require:
+
+- tight coupling to a specific memory backend
+- direct tool execution by LangGraph
+- OpenClaw core changes beyond plugin/runtime integration needs
+- immediate adoption of every upstream release
+
+## Recommended next artifacts
+
+After this policy, the project should add:
+
+1. `docs/langgraph-openclaw-git-workflow.md`
+2. `docs/langgraph-openclaw-compatibility-matrix.md`
+3. a small CI or local verification script for the contract gates
+

--- a/docs/langgraph-openclaw-git-workflow.md
+++ b/docs/langgraph-openclaw-git-workflow.md
@@ -1,0 +1,269 @@
+# LangGraph × OpenClaw Git Workflow
+
+## Goal
+
+This workflow keeps the LangGraph ↔ OpenClaw integration moving while both upstream projects continue to evolve.
+
+It is optimized for:
+
+- small reviewable PRs
+- explicit compatibility validation
+- low-risk upstream syncing
+- clear separation between stable work and exploratory work
+
+## Repository lanes
+
+Use the repository as an integration project with three logical lanes:
+
+1. **OpenClaw adapter lane**
+   - plugin entry
+   - hook wiring
+   - config handling
+   - host-specific degradation behavior
+
+2. **LangGraph runtime lane**
+   - runtime client
+   - runtime contract
+   - checkpoint / reflection / orchestration payloads
+
+3. **Compatibility lane**
+   - version matrix
+   - sync branches
+   - smoke tests
+   - upgrade notes
+
+## Branch model
+
+### Long-lived branches
+
+- `main`
+  - latest validated integration line
+  - safe default for consumers
+
+- `next`
+  - staging branch for upcoming validated work
+  - optional but recommended if upstream sync work becomes frequent
+
+### Short-lived branches
+
+#### Feature branches
+
+- `feat/plugin-<topic>`
+- `feat/runtime-<topic>`
+- `feat/contract-<topic>`
+
+Examples:
+
+- `feat/plugin-before-agent-start`
+- `feat/runtime-health-endpoint`
+- `feat/contract-before-compaction`
+
+#### Fix branches
+
+- `fix/openclaw-compat-<topic>`
+- `fix/langgraph-compat-<topic>`
+- `fix/runtime-<topic>`
+
+Examples:
+
+- `fix/openclaw-compat-pluginconfig`
+- `fix/langgraph-compat-checkpoint-payload`
+
+#### Test branches
+
+- `test/<topic>`
+
+Examples:
+
+- `test/plugin-host-smoke`
+- `test/compaction-contract`
+
+#### Docs branches
+
+- `docs/<topic>`
+
+Examples:
+
+- `docs/langgraph-compat-policy`
+- `docs/release-matrix-template`
+
+#### Upstream sync branches
+
+- `sync/openclaw-<version>`
+- `sync/langgraph-<version>`
+- `sync/openclaw-<version>-langgraph-<version>`
+
+Examples:
+
+- `sync/openclaw-0.9.4`
+- `sync/langgraph-0.2.61`
+- `sync/openclaw-0.9.4-langgraph-0.2.61`
+
+## PR types
+
+### Type A — Adapter PRs
+
+Changes one side of the boundary only.
+
+Examples:
+
+- read new OpenClaw config field
+- adjust LangGraph runtime payload key
+- improve degradation logging
+
+### Type B — Contract PRs
+
+Changes the integration contract itself.
+
+Examples:
+
+- add a field to `/runtime/before-agent-start`
+- change `before_compaction` archive payload shape
+
+These PRs must update tests and docs together.
+
+### Type C — Sync PRs
+
+Used when adopting a new upstream version.
+
+Examples:
+
+- support new OpenClaw plugin API behavior
+- support new LangGraph checkpoint semantics
+
+These PRs should avoid unrelated cleanup.
+
+### Type D — Docs/Test PRs
+
+No behavior change.
+
+Examples:
+
+- compatibility matrix update
+- smoke test extension
+- release notes
+
+## Normal delivery flow
+
+### Small feature flow
+
+1. branch from `main`
+2. implement one narrow change
+3. run local contract tests
+4. open PR
+5. merge after validation
+
+### Upstream sync flow
+
+1. branch from `main` into `sync/...`
+2. update one upstream target
+3. run full compatibility suite
+4. record outcomes in compatibility docs
+5. merge only if validated
+
+### Exploratory flow
+
+If behavior is not yet stable:
+
+1. branch from `main`
+2. keep work behind docs or optional config
+3. merge into `next` first if needed
+4. promote to `main` only after the contract settles
+
+## Required checks before merge
+
+### For adapter / contract changes
+
+Run at least:
+
+```bash
+node --test \
+  plugins/langgraph-orchestrator/runtime-helpers.test.mjs \
+  plugins/langgraph-orchestrator/runtime-client.test.mjs \
+  plugins/langgraph-orchestrator/plugin-host-smoke.test.mjs
+```
+
+### For upstream sync branches
+
+In addition to the above, verify:
+
+- plugin still loads
+- runtime health still works
+- `before_agent_start` still accepts and returns the expected shape
+- `agent_end` still degrades safely on failure
+- `before_compaction` still returns archive/checkpoint output compatibly
+
+## Commit discipline
+
+Each commit should ideally do one thing.
+
+Good examples:
+
+- `feat: add before-compaction runtime contract`
+- `fix: support updated openclaw hook payload`
+- `test: add langgraph health-check smoke case`
+- `docs: record supported version pair`
+
+Avoid commits that mix:
+
+- runtime contract changes
+- upstream version sync
+- docs rewrites
+- unrelated refactors
+
+## Rebase / merge guidance
+
+### Prefer rebase for short-lived branches
+
+Use rebase to keep the branch current when the change is small and linear.
+
+### Prefer squash merge for PRs
+
+Squash merge is a good default for this project because:
+
+- most PRs should answer one focused question
+- it keeps the integration history readable
+- it reduces noise from temporary fixup commits
+
+## When to cut a release tag
+
+Tag when all of the following are true:
+
+1. a version pair is explicitly validated
+2. contract docs match implementation
+3. smoke tests pass
+4. known limitations are documented
+
+Suggested tag style:
+
+- `langgraph-openclaw-v0.1.0`
+- `langgraph-openclaw-v0.1.1`
+
+## Operational habits
+
+### Do
+
+- isolate upstream syncs in dedicated branches
+- document supported version pairs
+- keep OpenClaw-facing and LangGraph-facing code in narrow boundary layers
+- update docs when a contract changes
+
+### Do not
+
+- mix OpenClaw and LangGraph upgrades in an unrelated feature PR
+- redefine `main` around untested upstream versions
+- let runtime failures block the main reply path
+- hide breaking contract changes inside refactors
+
+## Suggested next additions
+
+After adopting this workflow, add:
+
+1. `docs/langgraph-openclaw-compatibility-matrix.md`
+2. a small script that runs the compatibility suite
+3. a PR template section asking whether the change affects:
+   - OpenClaw boundary
+   - LangGraph boundary
+   - compatibility matrix
+   - docs/tests only
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "start:api": "python3 memory_api_server.py"
+    "start:api": "python3 memory_api_server.py",
+    "verify:langgraph-openclaw": "bash scripts/verify_langgraph_openclaw_contracts.sh"
   },
   "openclaw": {
     "extensions": [

--- a/scripts/verify_langgraph_openclaw_contracts.sh
+++ b/scripts/verify_langgraph_openclaw_contracts.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "==> LangGraph × OpenClaw compatibility verification"
+echo "Repo: $ROOT_DIR"
+
+echo
+echo "[1/3] Plugin host smoke + helper/runtime contract tests"
+node --test \
+  plugins/langgraph-orchestrator/runtime-helpers.test.mjs \
+  plugins/langgraph-orchestrator/runtime-client.test.mjs \
+  plugins/langgraph-orchestrator/plugin-host-smoke.test.mjs
+
+echo
+echo "[2/3] TypeScript typecheck"
+if [ -x ./node_modules/.bin/tsc ]; then
+  ./node_modules/.bin/tsc --noEmit
+else
+  echo "SKIP: ./node_modules/.bin/tsc not found"
+  echo "      Install project dependencies before using typecheck as a hard gate."
+fi
+
+echo
+echo "[3/3] Runtime endpoint contract checklist"
+cat <<'CHECKLIST'
+Manual/runtime-backed checks to run when validating a real version pair:
+- GET /health succeeds against the LangGraph runtime
+- POST /runtime/before-agent-start returns a compatible payload
+- POST /runtime/agent-end degrades safely on runtime failure
+- POST /runtime/before-compaction returns a compatible archive/checkpoint payload
+- OpenClaw main reply path stays non-blocking if the runtime is unavailable
+CHECKLIST
+
+echo
+echo "✅ Local contract verification completed"


### PR DESCRIPTION
## Summary

This PR adds the first project-level process docs for managing a LangGraph ↔ OpenClaw integration while both upstreams continue to evolve.

It does **not** change the runtime contract itself. Instead, it defines how the integration should be versioned, tested, and synchronized with upstream changes.

## What this adds

### Docs

- `docs/langgraph-openclaw-compatibility-policy.md`
- `docs/langgraph-openclaw-git-workflow.md`
- `docs/langgraph-openclaw-compatibility-matrix.md`

### Verification helper

- `scripts/verify_langgraph_openclaw_contracts.sh`
- `package.json` script: `verify:langgraph-openclaw`

## Why this matters

The LangGraph/OpenClaw integration now has two moving upstreams.
Without an explicit compatibility policy, the project risks:

- chasing upstream releases too aggressively
- mixing feature work with compatibility fixes
- losing track of validated version pairs
- breaking the integration contract silently

This PR gives the project:

- a stable-branch policy
- sync-branch conventions
- a compatibility matrix template
- a minimal repeatable local verification command

## Validation

Local verification helper:

```bash
npm run verify:langgraph-openclaw
```

Current expected behavior:

- lifecycle smoke tests pass
- runtime helper/client tests pass
- typecheck runs only if local `typescript` is installed
- runtime-backed checks remain explicitly listed for real version-pair validation

## Scope boundary

This PR is intentionally docs/test/process oriented:

- no new runtime endpoints
- no new plugin lifecycle behavior
- no new memory backend integration

## Suggested reviewer focus

- whether the branch / sync policy is conservative enough
- whether the compatibility matrix shape is useful
- whether the verification helper is the right minimal gate
